### PR TITLE
External models

### DIFF
--- a/crema/models/base.py
+++ b/crema/models/base.py
@@ -16,8 +16,13 @@ CORE_CUSTOM_OBJECTS = {k: layers.__dict__[k] for k in layers.__all__}
 
 
 class CremaModel(object):
+    name = None
     model_root = None
     custom_objects = {}
+
+    def __init__(self):
+        if self.name:
+            self._instantiate(self.name)
 
     def predict(self, filename=None, y=None, sr=None, outputs=None):
         '''Predict annotations


### PR DESCRIPTION
This lets you easily define a crema model that lives outside of the core repo, which I imagine most models are at some point before they get merged in. This has no effect on the default behavior and only matters for subclasses that modify these attributes. So for example:

```python
import crema
from .custom_layer import CustomLayer

class MyModel(crema.models.base.CremaModel):
    name = 'my_model'
    model_root = '~/.crema/models'
    custom_objects = {
        'CustomLayer': CustomLayer
    }
```

And voila - an externally defined model at `~/.crema/models/my_model` can be used as a crema model.