### PR TITLE
update: keras import

### DIFF
--- a/crema/layers.py
+++ b/crema/layers.py
@@ -2,7 +2,7 @@
 '''Custom Keras layers'''
 
 import keras.backend as K
-from keras.engine.topology import Layer
+from keras.layers import Layer
 
 
 __all__ = ['SqueezeLayer']


### PR DESCRIPTION
The newer versions (I think 2.5+) of keras no longer have `keras.engine.topology` and the `Layer` class needs to be imported from `keras.layers` instead